### PR TITLE
add x86_64-linux to gemlock file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     pg (1.4.3)
     puma (3.12.6)
     racc (1.6.0)
@@ -146,6 +148,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)


### PR DESCRIPTION
Please include a summary of the changes and/or which issue is fixed. Please also include relevant motivation and context. 
Gemfile.lock needed platform x86_64-linux (via heroku error logs) so that update was made. This final change should allow for continuous deployment
Were there any issues that arose? 
No.
## Issues
Closes #

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor feature (non-breaking change that modifies existing work)
- [ ] Cosmetic changes (changes to layout or visuals in CSS file)

# How Has This Been Tested?
- This successfully builds on CircleCI, but we will see if it continuously deploys

# Checklist:
- [x] My code follows the style guidelines of this project (semicolons, indentation, naming conventions, etc..).
- [x] I have performed a self-review of my code.
- [ ] I have deleted all comments and console.logs after functionality and understanding is final.
- [ ] I have added any issues closed by this PR in the Issues section.
- [ ] I have added others as reviewers (when applicable).
